### PR TITLE
Fix blurred font when using MS IME theme

### DIFF
--- a/ibus-tweaker@tuberry.github.com/stylesheet.css
+++ b/ibus-tweaker@tuberry.github.com/stylesheet.css
@@ -6,6 +6,7 @@
 
 
 .ibus-tweaker-candidate-popup-content {
+    margin: 0.3em;
     border-radius: 0.2em;
     border-width: 1px;
     padding: 0;
@@ -39,7 +40,6 @@
 .ibus-tweaker-candidate-popup-boxpointer {
     -arrow-background-color: transparent;
     -arrow-border-radius: 0.75em;
-    -arrow-rise: 0.3em;
 }
 
 /*


### PR DESCRIPTION
My main OS is openSUSE Tumbleweed 20210611 (GNOME 40), when using the styles provided in the [stylesheet.css](https://github.com/tuberry/ibus-tweaker/blob/master/ibus-tweaker%40tuberry.github.com/stylesheet.css), I always get a blurred font in the candidate box. And the situation is also the same in Manjaro (GNOME 3.38):
![2021-06-15 20-28-56屏幕截图](https://user-images.githubusercontent.com/43995067/122061581-3bf3ad00-ce21-11eb-98b4-1fdce84ccf47.png)

Finally I can fix this by changing the unit of `-arrow-rise`, replacing `em` to `px`.
It may be a Bug in GNOME, but replacing it do make a workaround.
![2021-06-15 20-45-48屏幕截图](https://user-images.githubusercontent.com/43995067/122062500-0bf8d980-ce22-11eb-9ca9-bbdaaf55ac73.png)

Signed-off-by: Hollow Man <hollowman@hollowman.ml>