### PR TITLE
fix: raise IBus candidate popup above screenshot UI when active

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -479,8 +479,14 @@ class IBusTweaker extends F.Mortal {
             [K.THM, PresetTheme],
         ];
         this.$set = new F.Setting(gset, this, tweaks.map(([k]) => [k, null, x => this.$src[k].toggle(x)]));
-        this.$src = F.Source.tie(this, Object.fromEntries(tweaks.map(([k, v]) => [k, F.Source.new(() => new v(this.$set), this[k])])));
-    }
+        this.$src = F.Source.tie(this, Object.fromEntries(tweaks.map(([k, v]) => [k, F.Source.new(() => new v(this.$set), this[k])])),
+            F.Source.newInjector([
+                IBusPopup, {_updateVisibility: (a, f, xs) => {
+                    f.apply(a, xs);
+                    if (a.visible)
+                        a.get_parent().set_child_above_sibling(a, null);
+                }}, // HACK: workaround for https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/4264
+            ], true));
 }
 
 export default class extends F.Extension { $klass = IBusTweaker; }


### PR DESCRIPTION
Apply the fix from GNOME Shell MR !4264 to ensure the IBus input method candidate popup is always visible above the screenshot UI by raising it to the top of the layer stack when active.

Ref: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/4264

---

感觉 GNOME shell 上游不会合并这个 PR，所以觉得放到这里也挺合适的